### PR TITLE
Cache cargo builds on the local machine for vagrant deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /tmp/
 /.vagrant/
+/target/

--- a/remote.justfile
+++ b/remote.justfile
@@ -35,9 +35,17 @@ install-base-packages:
   touch ~/.hushlogin
 
 install-rust:
+  #!/usr/bin/env bash
+  set -euxo pipefail
+
   rustup --version || \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --no-modify-path
+
+  if [[ `hostname` == vagrant ]]; then
+    export CARGO_TARGET_DIR="/vagrant/target"
+  fi
+
   cargo install rust-script
 
 setup-volume:

--- a/setup-lightning
+++ b/setup-lightning
@@ -1,7 +1,7 @@
 #!/usr/bin/env rust-script
 //! ```cargo
 //! [dependencies]
-//! cradle = "=0.0.13"
+//! cradle = "=0.0.14"
 //! lazy_static = "=1.4.0"
 //! serde_yaml = "=0.8.17"
 //! which = "=4.1.0"
@@ -166,7 +166,17 @@ fn setup_agora() {
         cmd_unit!(%"git clone https://github.com/agora-org/agora.git");
     }
     cmd_unit!(LogCommand, CurrentDir("agora"), %"git pull --ff-only");
-    cmd_unit!(LogCommand, CurrentDir("agora"), %"cargo install --path . --root /usr/local --force");
+    let StdoutTrimmed(hostname) = cmd!("hostname");
+    cmd_unit!(
+        LogCommand,
+        CurrentDir("agora"),
+        if hostname == "vagrant" {
+            vec![Env("CARGO_TARGET_DIR", "/vagrant/target")]
+        } else {
+            vec![]
+        },
+        %"cargo install --path . --root /usr/local --force"
+    );
 
     cmd_unit!(%"mkdir -p /srv/agora");
     cmd_unit!(%"cp agora/README.md /srv/agora/");


### PR DESCRIPTION
This makes deployments to fresh vagrant instances faster. We do rely on `cargo` to do caching in the `target` directory correctly.

Another option would be to somehow mount a `target` directory into the remote machine over ssh. Then that could also work for `kos` and `athens`, although caching `cargo` builds on those machines is not really that important. It would mean that the vagrant setup stays closer to the production machines.