### PR TITLE
Restart agora slower and more often in case it fails

### DIFF
--- a/agora.service
+++ b/agora.service
@@ -1,6 +1,8 @@
 [Unit]
-Description=Agora daemon
 After=network.target
+Description=Agora daemon
+StartLimitBurst=120
+StartLimitIntervalSec=10m
 
 [Service]
 AmbientCapabilities=CAP_NET_BIND_SERVICE
@@ -16,7 +18,8 @@ ExecStart=/usr/local/bin/agora \
 
 Type=simple
 Restart=on-failure
-TimeoutStopSec=600
+TimeoutStopSec=10m
+RestartSec=5s
 
 # Directory creation and permissions
 ####################################


### PR DESCRIPTION
This applies the same restarting policies to `agora.service` that are in place for `lnd.service`. The old policies meant that `agora` could get into a failed state when `lnd` was not up yet. This could be triggered by e.g. `systemctl restart bitcoind.service lnd.service agora.service`. But at least on `vagrant` I have also seen this after a system reboot.

We probably can (and should) revert this once https://github.com/agora-org/agora/issues/95 is implemented.